### PR TITLE
add: CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# DevOps team code owner configuration
+
+**/Dockerfile @Koudmain/Koudmain-team-devops
+**/.dockerignore @Koudmain/Koudmain-team-devops
+**/docker-compose.* @Koudmain/Koudmain-team-devops
+**/Makefile @Koudmain/Koudmain-team-devops
+.github/ @Koudmain/Koudmain-team-devops


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to assign the DevOps team as code owners for key configuration and infrastructure files. This ensures that the DevOps team will be automatically requested for review on changes to these files.

Ownership assignment:

* Added the DevOps team (`@Koudmain/Koudmain-team-devops`) as code owners for all `Dockerfile`, `.dockerignore`, `docker-compose.*`, `Makefile`, and all files under the `.github/` directory.